### PR TITLE
Exit codes and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,26 @@ See the [CI workflow](.github/workflows/ci.yml) for more details.
 Download the prebuilt binaries from the
 [Releases](https://github.com/iamazeem/spancopy/releases) page.
 
+## Install
+
+### Install: Windows (`winget`)
+
+```powershell
+# Install with alias
+winget.exe install spancopy
+
+# Install with id
+winget.exe install --id iamAzeem.spancopy
+```
+
 ## Usage
 
 Run `spancopy --help` for usage.
 
 ```text
-$ ./spancopy --help
+$ spancopy --help
 spancopy v0.0.1 - a CLI tool to span (copy) files with size threshold
-Usage: ./spancopy [OPTIONS]
+Usage: spancopy [OPTIONS]
 
 Options:
   -h,--help                   show help and exit
@@ -73,7 +85,7 @@ Examples:
   spancopy --threshold 100kb --source ./src --destination ./dst
 
 For any feedback or to report any issues, please open an issue on
-GitHub: https://github.com/iamazeem/spancopy
+GitHub: https://github.com/iamazeem/spancopy/issues
 
 Written by: AZEEM SAJID <azeem.sajid@gmail.com>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,16 +69,22 @@ int main(int argc, char** argv)
     {
         app.parse(argc, argv);
     }
-    catch (const CLI::Success& e)
+    catch (const CLI::CallForVersion& e)
     {
-        // -h,--help or -v,--version
-        app.exit(e);
-        return EXIT_SUCCESS;
+        return app.exit(e);
+    }
+    catch (const CLI::CallForHelp& e)
+    {
+        return app.exit(e);
     }
     catch (const CLI::ParseError& e)
     {
-        app.exit(e);
-        return EXIT_FAILURE;
+        if (argc == 1)
+        {
+            return app.exit(CLI::CallForHelp{});
+        }
+
+        return app.exit(e);
     }
 
     const spancopy::spanner spanner{threshold, source, destination};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
         "  spancopy --threshold 100kb --source ./src --destination ./dst\n"
         "\n"
         "For any feedback or to report any issues, please open an issue on\n"
-        "GitHub: https://github.com/iamazeem/spancopy\n"
+        "GitHub: https://github.com/iamazeem/spancopy/issues\n"
         "\n"
         "Written by: AZEEM SAJID <azeem.sajid@gmail.com>\n"
     );


### PR DESCRIPTION
- Return exit code if no CLI args are passed
  - Needed for winget validation test to pass when publishing package
- Update README for winget installation instructions

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>