### PR TITLE
[CI][Windows] Update file version info

### DIFF
--- a/src/resource.rc
+++ b/src/resource.rc
@@ -13,6 +13,10 @@ BEGIN
     BEGIN
         BLOCK "040904E4"
         BEGIN
+            VALUE "FileDescription",  "spancopy - a CLI tool to span (copy) files with size threshold"
+            VALUE "FileVersion",      VERSION
+            VALUE "InternalName",     "spancopy"
+            VALUE "OriginalFilename", "spancopy.exe"
             VALUE "ProductName",      "spancopy"
             VALUE "ProductVersion",   VERSION
         END


### PR DESCRIPTION
- Updated file version info to be available for Powershell commands

Example:

```pwsh
PS Z:\> (Get-Item .\spancopy.exe).VersionInfo

ProductVersion   FileVersion      FileName
--------------   -----------      --------
0.0.4            0.0.4            Z:\spancopy.exe

PS Z:\> (Get-Item .\spancopy.exe).VersionInfo | Format-List

OriginalFilename  : spancopy.exe
FileDescription   : spancopy - a CLI tool to span (copy) files with size threshold
ProductName       : spancopy
Comments          :
CompanyName       :
FileName          : Z:\spancopy.exe
FileVersion       : 0.0.4
ProductVersion    : 0.0.4
IsDebug           : False
IsPatched         : False
IsPreRelease      : False
IsPrivateBuild    : False
IsSpecialBuild    : False
Language          : English (United States)
LegalCopyright    :
LegalTrademarks   :
PrivateBuild      :
SpecialBuild      :
FileVersionRaw    : 0.0.0.0
ProductVersionRaw : 0.0.0.0
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>