### PR TITLE
[CI] Publish Linux packages

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -7,3 +7,4 @@
 --maintainer "Azeem Sajid <azeem.sajid@gmail.com>"
 --url "https://github.com/iamazeem/spancopy"
 --license "MIT"
+--prefix "/usr/local/bin"

--- a/.fpm
+++ b/.fpm
@@ -1,0 +1,9 @@
+--input-type zip
+--output-type deb
+--name "spancopy"
+--version "0.0.0"
+--architecture "amd64"
+--description "a CLI tool to span (copy) files with size threshold"
+--maintainer "Azeem Sajid <azeem.sajid@gmail.com>"
+--url "https://github.com/iamazeem/spancopy"
+--license "MIT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
         if-no-files-found: error
 
   prepare-linux-packages:
-    # if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     needs: [version, ci]
     runs-on: ubuntu-latest
 
@@ -303,7 +303,7 @@ jobs:
         path: packages
 
   publish-linux-packages:
-    # if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
     needs: [prepare-linux-packages]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,9 @@ jobs:
     - name: Download ZIP artifacts
       uses: actions/download-artifact@v4
       with:
-        name: spancopy-${{ env.TAG }}-*-linux.zip
+        pattern: spancopy-${{ env.TAG }}-*-linux.zip
+        path: ${{ github.workspace }}/.artifacts
         merge-multiple: true
 
     - name: Check
-      run: ls -hl
+      run: ls -hl .artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,6 @@ jobs:
       run: |
         for ARCH in amd64 arm64; do
           createrepo_c packages/rpm/"$ARCH"
-          cd -
         done
 
     - name: Upload GitHub Pages artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,21 +90,21 @@ jobs:
           cxx: aarch64-linux-gnu-g++
           strip: aarch64-linux-gnu-strip
           tests: false
-        # - os: ubuntu-latest
-        #   prefix: amd64-windows
-        #   cxx: x86_64-w64-mingw32-g++
-        #   strip: x86_64-w64-mingw32-strip
-        #   tests: false
-        # - os: macos-13
-        #   prefix: amd64-macosx
-        #   cxx: clang++
-        #   strip: strip
-        #   tests: true
-        # - os: macos-latest
-        #   prefix: arm64-macosx
-        #   cxx: clang++
-        #   strip: strip
-        #   tests: true
+        - os: ubuntu-latest
+          prefix: amd64-windows
+          cxx: x86_64-w64-mingw32-g++
+          strip: x86_64-w64-mingw32-strip
+          tests: false
+        - os: macos-13
+          prefix: amd64-macosx
+          cxx: clang++
+          strip: strip
+          tests: true
+        - os: macos-latest
+          prefix: arm64-macosx
+          cxx: clang++
+          strip: strip
+          tests: true
 
     runs-on: ${{ matrix.config.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,10 @@ jobs:
       TAG: ${{ needs.version.outputs.TAG }}
       AMD64_ZIP: spancopy-${{ needs.version.outputs.TAG }}-amd64-linux.zip
       ARM64_ZIP: spancopy-${{ needs.version.outputs.TAG }}-arm64-linux.zip
+      AMD64_DEB: spancopy_${{ needs.version.outputs.TAG }}_amd64.deb
+      ARM64_DEB: spancopy_${{ needs.version.outputs.TAG }}_arm64.deb
+      AMD64_RPM: spancopy-${{ needs.version.outputs.TAG }}-1.x86_64.rpm
+      ARM64_RPM: spancopy-${{ needs.version.outputs.TAG }}-1.aarch64.rpm
 
     steps:
     - name: Checkout .fpm config file
@@ -223,9 +227,6 @@ jobs:
         sudo gem install --no-document fpm
 
     - name: Build DEB packages
-      env:
-        AMD64_DEB: spancopy_${{ env.TAG }}_amd64.deb
-        ARM64_DEB: spancopy_${{ env.TAG }}_arm64.deb
       run: |
         cd "$ARTIFACT_DIR"
         ls -hl *.zip
@@ -246,9 +247,6 @@ jobs:
         ls -hl *.deb
 
     - name: Build RPM packages
-      env:
-        AMD64_RPM: spancopy-${{ env.TAG }}-1.x86_64.rpm
-        ARM64_RPM: spancopy-${{ env.TAG }}-1.aarch64.rpm
       run: |
         cd "$ARTIFACT_DIR"
         ls -hl *.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
 
-  publish-linux-packages:
+  prepare-linux-packages:
     # if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     needs: [version, ci]
     runs-on: ubuntu-latest
@@ -212,7 +212,9 @@ jobs:
     - name: Checkout .fpm config file
       uses: actions/checkout@v4
       with:
-        sparse-checkout: .fpm
+        sparse-checkout: |
+          .fpm
+          packages
 
     - name: Download ZIP artifacts
       uses: actions/download-artifact@v4
@@ -223,7 +225,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install -y rpm
+        sudo apt update
+        sudo apt install -y rpm dpkg-dev createrepo-c
         sudo gem install --no-document fpm
 
     - name: Build DEB packages
@@ -267,3 +270,53 @@ jobs:
         rpm -qip "$ARM64_RPM"
         rpm -qlp "$ARM64_RPM"
         ls -hl *.rpm
+
+    - name: Move deb and rpm files to packages directory
+      run: |
+        mkdir -p packages/{apt,rpm}/{amd64,arm64}
+        mv "$ARTIFACT_DIR/$AMD64_DEB" packages/apt/amd64/
+        mv "$ARTIFACT_DIR/$ARM64_DEB" packages/apt/arm64/
+        mv "$ARTIFACT_DIR/$AMD64_RPM" packages/rpm/amd64/
+        mv "$ARTIFACT_DIR/$ARM64_RPM" packages/rpm/arm64/
+        ls -hl packages/{apt,rpm}/{amd64,arm64}
+
+    - name: Update APT repository
+      run: |
+        for ARCH in amd64 arm64; do
+          cd packages/apt/"$ARCH"
+          dpkg-scanpackages . /dev/null > Packages
+          gzip -k -f Packages
+          apt-ftparchive release . > Release
+        done
+
+    - name: Update RPM repository
+      run: |
+        for ARCH in amd64 arm64; do
+          createrepo_c packages/rpm/"$ARCH"
+        done
+
+    - name: Upload GitHub Pages artifacts
+      uses: actions/upload-pages-artifact@v3
+      with:
+        name: packages
+        path: packages
+
+  publish-linux-packages:
+    # if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: [prepare-linux-packages]
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/packages
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+      with:
+        artifact_name: packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,9 @@ jobs:
         merge-multiple: true
 
     - name: Install dependencies
-      run: sudo gem install --no-document fpm
+      run: |
+        sudo apt install -y rpm
+        sudo gem install --no-document fpm
 
     - name: Build DEB packages
       run: |
@@ -235,3 +237,22 @@ jobs:
         ls -hl *.deb
         dpkg --info *.deb
         dpkg --contents *.deb
+
+    - name: Build RPM packages
+      run: |
+        cd "$ARTIFACT_DIR"
+        ls -hl *.zip
+        fpm \
+          --fpm-options-file ../.fpm \
+          --output-type rpm \
+          --architecture amd64 \
+          --version "$TAG" \
+          "spancopy-$TAG-amd64-linux.zip"
+        fpm \
+          --fpm-options-file ../.fpm \
+          --output-type rpm \
+          --architecture arm64 \
+          --version "$TAG" \
+          "spancopy-$TAG-arm64-linux.zip"
+        ls -hl *.rpm
+        rpm -qip *.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,8 @@ jobs:
 
     env:
       TAG: ${{ needs.version.outputs.TAG }}
+      AMD64_ZIP: spancopy_${{ needs.version.outputs.TAG }}_amd64-linux.zip
+      ARM64_ZIP: spancopy_${{ needs.version.outputs.TAG }}_arm64-linux.zip
 
     steps:
     - name: Checkout .fpm config file
@@ -221,6 +223,9 @@ jobs:
         sudo gem install --no-document fpm
 
     - name: Build DEB packages
+      env:
+        AMD64_DEB: spancopy_${{ env.TAG }}_amd64.deb
+        ARM64_DEB: spancopy_${{ env.TAG }}_arm64.deb
       run: |
         cd "$ARTIFACT_DIR"
         ls -hl *.zip
@@ -228,36 +233,39 @@ jobs:
           --fpm-options-file ../.fpm \
           --architecture "amd64" \
           --version "$TAG" \
-          "spancopy-$TAG-amd64-linux.zip"
-        dpkg --info ./"spancopy_$TAG_amd64.deb"
-        dpkg --contents ./"spancopy_$TAG_amd64.deb"
+          "$AMD64_ZIP"
+        dpkg --info "$AMD64_DEB"
+        dpkg --contents "$AMD64_DEB"
         fpm \
           --fpm-options-file ../.fpm \
-          --architecture arm64 \
+          --architecture "arm64" \
           --version "$TAG" \
-          "spancopy-$TAG-arm64-linux.zip"
-        dpkg --info ./"spancopy_$TAG_arm64.deb"
-        dpkg --contents ./"spancopy_$TAG_arm64.deb"
+          "$ARM64_ZIP"
+        dpkg --info "$ARM64_DEB"
+        dpkg --contents "$ARM64_DEB"
         ls -hl *.deb
 
     - name: Build RPM packages
+      env:
+        AMD64_RPM: spancopy-${{ env.TAG }}-1.x86_64.rpm
+        ARM64_RPM: spancopy-${{ env.TAG }}-1.aarch64.rpm
       run: |
         cd "$ARTIFACT_DIR"
         ls -hl *.zip
         fpm \
           --fpm-options-file ../.fpm \
           --output-type rpm \
-          --architecture amd64 \
+          --architecture "amd64" \
           --version "$TAG" \
-          "spancopy-$TAG-amd64-linux.zip"
-        rpm -qip ./"spancopy-$TAG-1.x86_64.rpm"
-        rpm -qlp ./"spancopy-$TAG-1.x86_64.rpm"
+          "$AMD64_ZIP"
+        rpm -qip "$AMD64_RPM"
+        rpm -qlp "$AMD64_RPM"
         fpm \
           --fpm-options-file ../.fpm \
           --output-type rpm \
-          --architecture arm64 \
+          --architecture "arm64" \
           --version "$TAG" \
-          "spancopy-$TAG-arm64-linux.zip"
-        rpm -qip ./"spancopy-$TAG-1.aarch64.rpm"
-        rpm -qlp ./"spancopy-$TAG-1.aarch64.rpm"
+          "$ARM64_ZIP"
+        rpm -qip "$ARM64_RPM"
+        rpm -qlp "$ARM64_RPM"
         ls -hl *.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,12 +203,35 @@ jobs:
       TAG: ${{ needs.version.outputs.TAG }}
 
     steps:
+    - name: Checkout .fpm config file
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .fpm
+
     - name: Download ZIP artifacts
       uses: actions/download-artifact@v4
       with:
         pattern: spancopy-${{ env.TAG }}-*-linux.zip
-        path: ${{ github.workspace }}/.artifacts
+        path: ${{ env.ARTIFACT_DIR }}
         merge-multiple: true
 
-    - name: Check
-      run: ls -hl .artifacts
+    - name: Install dependencies
+      run: sudo gem install --no-document fpm
+
+    - name: Build DEB packages
+      run: |
+        cd "$ARTIFACT_DIR"
+        ls -hl *.zip
+        fpm \
+          --fpm-options-file ../.fpm \
+          --architecture amd64 \
+          --version "$TAG" \
+          "spancopy-$TAG-amd64-linux.zip"
+        fpm \
+          --fpm-options-file ../.fpm \
+          --architecture arm64 \
+          --version "$TAG" \
+          "spancopy-$TAG-arm64-linux.zip"
+        ls -hl *.deb
+        dpkg --info *.deb
+        dpkg --contents *.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
   ARTIFACT_DIR: .artifacts
   ARTIFACT_RETENTION_DAYS: 5
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -160,10 +164,6 @@ jobs:
     needs: [version, ci]
     runs-on: windows-latest
 
-    defaults:
-      run:
-        shell: bash
-
     steps:
     - name: Install wingetcreate
       run: |
@@ -193,3 +193,21 @@ jobs:
         path: ${{ github.workspace }}/manifests
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
+
+  publish-linux-packages:
+    # if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    needs: [version, ci]
+    runs-on: ubuntu-latest
+
+    env:
+      TAG: ${{ needs.version.outputs.TAG }}
+      AMD64_LINUX_ZIP: spancopy-${{ needs.version.outputs.TAG }}-amd64-linux.zip
+
+    steps:
+    - name: Download ZIP artifact (${{ env.AMD64_LINUX_ZIP }})
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.AMD64_LINUX_ZIP }}
+
+    - name: Check
+      run: ls -hl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,12 +287,14 @@ jobs:
           dpkg-scanpackages . /dev/null > Packages
           gzip -k -f Packages
           apt-ftparchive release . > Release
+          cd -
         done
 
     - name: Update RPM repository
       run: |
         for ARCH in amd64 arm64; do
           createrepo_c packages/rpm/"$ARCH"
+          cd -
         done
 
     - name: Upload GitHub Pages artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,21 +90,21 @@ jobs:
           cxx: aarch64-linux-gnu-g++
           strip: aarch64-linux-gnu-strip
           tests: false
-        - os: ubuntu-latest
-          prefix: amd64-windows
-          cxx: x86_64-w64-mingw32-g++
-          strip: x86_64-w64-mingw32-strip
-          tests: false
-        - os: macos-13
-          prefix: amd64-macosx
-          cxx: clang++
-          strip: strip
-          tests: true
-        - os: macos-latest
-          prefix: arm64-macosx
-          cxx: clang++
-          strip: strip
-          tests: true
+        # - os: ubuntu-latest
+        #   prefix: amd64-windows
+        #   cxx: x86_64-w64-mingw32-g++
+        #   strip: x86_64-w64-mingw32-strip
+        #   tests: false
+        # - os: macos-13
+        #   prefix: amd64-macosx
+        #   cxx: clang++
+        #   strip: strip
+        #   tests: true
+        # - os: macos-latest
+        #   prefix: arm64-macosx
+        #   cxx: clang++
+        #   strip: strip
+        #   tests: true
 
     runs-on: ${{ matrix.config.os }}
 
@@ -226,17 +226,19 @@ jobs:
         ls -hl *.zip
         fpm \
           --fpm-options-file ../.fpm \
-          --architecture amd64 \
+          --architecture "amd64" \
           --version "$TAG" \
           "spancopy-$TAG-amd64-linux.zip"
+        dpkg --info "spancopy_$TAG_amd64.deb"
+        dpkg --contents "spancopy_$TAG_amd64.deb"
         fpm \
           --fpm-options-file ../.fpm \
           --architecture arm64 \
           --version "$TAG" \
           "spancopy-$TAG-arm64-linux.zip"
+        dpkg --info "spancopy_$TAG_arm64.deb"
+        dpkg --contents "spancopy_$TAG_arm64.deb"
         ls -hl *.deb
-        dpkg --info *.deb
-        dpkg --contents *.deb
 
     - name: Build RPM packages
       run: |
@@ -248,11 +250,14 @@ jobs:
           --architecture amd64 \
           --version "$TAG" \
           "spancopy-$TAG-amd64-linux.zip"
+        rpm -qip "spancopy-$TAG-1.x86_64.rpm"
+        rpm -qlp "spancopy-$TAG-1.x86_64.rpm"
         fpm \
           --fpm-options-file ../.fpm \
           --output-type rpm \
           --architecture arm64 \
           --version "$TAG" \
           "spancopy-$TAG-arm64-linux.zip"
+        rpm -qip "spancopy-$TAG-1.aarch64.rpm"
+        rpm -qlp "spancopy-$TAG-1.aarch64.rpm"
         ls -hl *.rpm
-        rpm -qip *.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,15 +229,15 @@ jobs:
           --architecture "amd64" \
           --version "$TAG" \
           "spancopy-$TAG-amd64-linux.zip"
-        dpkg --info "spancopy_$TAG_amd64.deb"
-        dpkg --contents "spancopy_$TAG_amd64.deb"
+        dpkg --info ./"spancopy_$TAG_amd64.deb"
+        dpkg --contents ./"spancopy_$TAG_amd64.deb"
         fpm \
           --fpm-options-file ../.fpm \
           --architecture arm64 \
           --version "$TAG" \
           "spancopy-$TAG-arm64-linux.zip"
-        dpkg --info "spancopy_$TAG_arm64.deb"
-        dpkg --contents "spancopy_$TAG_arm64.deb"
+        dpkg --info ./"spancopy_$TAG_arm64.deb"
+        dpkg --contents ./"spancopy_$TAG_arm64.deb"
         ls -hl *.deb
 
     - name: Build RPM packages
@@ -250,14 +250,14 @@ jobs:
           --architecture amd64 \
           --version "$TAG" \
           "spancopy-$TAG-amd64-linux.zip"
-        rpm -qip "spancopy-$TAG-1.x86_64.rpm"
-        rpm -qlp "spancopy-$TAG-1.x86_64.rpm"
+        rpm -qip ./"spancopy-$TAG-1.x86_64.rpm"
+        rpm -qlp ./"spancopy-$TAG-1.x86_64.rpm"
         fpm \
           --fpm-options-file ../.fpm \
           --output-type rpm \
           --architecture arm64 \
           --version "$TAG" \
           "spancopy-$TAG-arm64-linux.zip"
-        rpm -qip "spancopy-$TAG-1.aarch64.rpm"
-        rpm -qlp "spancopy-$TAG-1.aarch64.rpm"
+        rpm -qip ./"spancopy-$TAG-1.aarch64.rpm"
+        rpm -qlp ./"spancopy-$TAG-1.aarch64.rpm"
         ls -hl *.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,8 @@ jobs:
 
     env:
       TAG: ${{ needs.version.outputs.TAG }}
-      AMD64_ZIP: spancopy_${{ needs.version.outputs.TAG }}_amd64-linux.zip
-      ARM64_ZIP: spancopy_${{ needs.version.outputs.TAG }}_arm64-linux.zip
+      AMD64_ZIP: spancopy-${{ needs.version.outputs.TAG }}-amd64-linux.zip
+      ARM64_ZIP: spancopy-${{ needs.version.outputs.TAG }}-arm64-linux.zip
 
     steps:
     - name: Checkout .fpm config file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
 
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}/packages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
     - name: Deploy to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,13 @@ jobs:
 
     env:
       TAG: ${{ needs.version.outputs.TAG }}
-      AMD64_LINUX_ZIP: spancopy-${{ needs.version.outputs.TAG }}-amd64-linux.zip
 
     steps:
-    - name: Download ZIP artifact (${{ env.AMD64_LINUX_ZIP }})
+    - name: Download ZIP artifacts
       uses: actions/download-artifact@v4
       with:
-        name: ${{ env.AMD64_LINUX_ZIP }}
+        name: spancopy-${{ env.TAG }}-*-linux.zip
+        merge-multiple: true
 
     - name: Check
       run: ls -hl

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ Download the prebuilt binaries from the
 
 ## Install
 
+### Install: Linux (`apt`)
+
+```shell
+# Add repository
+echo "deb [trusted=yes] https://iamazeem.github.io/spancop/apt/$(dpkg --print-architecture)/ ./" | \
+    sudo tee /etc/apt/sources.list.d/spancopy.list
+
+# Install package
+sudo apt update
+sudo apt install spancopy
+```
+
+### Install: Linux (`rpm`)
+
+```shell
+# Add repository
+sudo tee /etc/yum.repos.d/spancopy.repo << EOF
+[spancopy]
+name=spancopy Repository
+baseurl=https://iamazeem.github.io/spancopy/rpm/\$basearch
+enabled=1
+gpgcheck=0
+EOF
+
+# Install package
+sudo yum install spancopy
+```
+
 ### Install: Windows (`winget`)
 
 ```powershell

--- a/packages/index.html
+++ b/packages/index.html
@@ -9,20 +9,30 @@
     <h1>spancopy Package Repository</h1>
 
     <h2>APT Repository</h2>
-    <p>Add to <code>/etc/apt/sources.list.d/spancopy.list</code>:</p>
-    <code>
-        deb [trusted=yes] https://iamazeem.github.io/spancopy/apt/\$(dpkg --print-architecture)/ ./
-    </code>
+    <pre>
+        # Add repository
+        echo "deb [trusted=yes] https://iamazeem.github.io/spancop/apt/$(dpkg --print-architecture)/ ./" | \
+            sudo tee /etc/apt/sources.list.d/spancopy.list
+
+        # Install package
+        sudo apt update
+        sudo apt install spancopy
+    </pre>
 
     <h2>RPM Repository</h2>
-    <p>Add to <code>/etc/yum.repos.d/spancopy.repo</code>:</p>
-    <code>
+    <pre>
+        # Add repository
+        sudo tee /etc/yum.repos.d/spancopy.repo << EOF
         [spancopy]
-        name=SpanCopy Repository
+        name=spancopy Repository
         baseurl=https://iamazeem.github.io/spancopy/rpm/\$basearch
         enabled=1
         gpgcheck=0
-    </code>
+        EOF
+
+        # Install package
+        sudo yum install spancopy
+    </pre>
 </body>
 
 </html>

--- a/packages/index.html
+++ b/packages/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>spancopy Package Repository</title>
+</head>
+
+<body>
+    <h1>spancopy Package Repository</h1>
+
+    <h2>APT Repository</h2>
+    <p>Add to <code>/etc/apt/sources.list.d/spancopy.list</code>:</p>
+    <code>
+        deb [trusted=yes] https://iamazeem.github.io/spancopy/packages/apt/\$(dpkg --print-architecture)/ ./
+    </code>
+
+    <h2>RPM Repository</h2>
+    <p>Add to <code>/etc/yum.repos.d/spancopy.repo</code>:</p>
+    <code>
+        [spancopy]
+        name=SpanCopy Repository
+        baseurl=https://iamazeem.github.io/spancopy/packages/rpm/\$basearch
+        enabled=1
+        gpgcheck=0
+    </code>
+</body>
+
+</html>

--- a/packages/index.html
+++ b/packages/index.html
@@ -11,7 +11,7 @@
     <h2>APT Repository</h2>
     <p>Add to <code>/etc/apt/sources.list.d/spancopy.list</code>:</p>
     <code>
-        deb [trusted=yes] https://iamazeem.github.io/spancopy/packages/apt/\$(dpkg --print-architecture)/ ./
+        deb [trusted=yes] https://iamazeem.github.io/spancopy/apt/\$(dpkg --print-architecture)/ ./
     </code>
 
     <h2>RPM Repository</h2>
@@ -19,7 +19,7 @@
     <code>
         [spancopy]
         name=SpanCopy Repository
-        baseurl=https://iamazeem.github.io/spancopy/packages/rpm/\$basearch
+        baseurl=https://iamazeem.github.io/spancopy/rpm/\$basearch
         enabled=1
         gpgcheck=0
     </code>


### PR DESCRIPTION
Fixes #12.

- Added jobs for preparing and publishing Linux APT and RPM packages
- Configured packages to be hosted via GitHub Pages on a new release
- Updated README for installation instructions
  - Added the same to the default HTML page i.e. https://iamazeem.github.io/spancopy

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>